### PR TITLE
Fix bundel typo

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -161,7 +161,7 @@
 
           // Exclude bundle configurations if useBundles option is not specified
           if (!karma.config.systemjs.useBundles) {
-            karma.config.systemjs.config.bundels = [];
+            karma.config.systemjs.config.bundles = [];
           }
 
           System.config(karma.config.systemjs.config);


### PR DESCRIPTION
Pretty sure 'bundels' is a typo, and 'bundles' is what was meant.